### PR TITLE
Add Snyk badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version](https://img.shields.io/npm/v/@wowserhq/stormjs.svg?style=flat)](https://www.npmjs.org/package/@wowserhq/stormjs)
 [![Build Status](https://travis-ci.org/wowserhq/stormjs.svg?branch=master)](https://travis-ci.org/wowserhq/stormjs)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/829e88cf1899d0061b88/test_coverage)](https://codeclimate.com/github/wowserhq/stormjs/test_coverage)
+[![Vulnerabilities](https://snyk.io/test/github/wowserhq/stormjs/badge.svg?targetFile=package.json)](https://snyk.io/test/github/wowserhq/stormjs?targetFile=package.json)
 
 StormJS is [StormLib](http://www.zezula.net/en/mpq/stormlib.html) for Javascript, powered by
 [Emscripten](http://emscripten.org).


### PR DESCRIPTION
One caveat to keep in mind: Snyk's GitHub integration doesn't check `devDependencies`. In theory, we could have vulnerabilities that sneak in via flaws in `emscripten`, `babel`, etc. Apparently Snyk's CLI can check `devDependencies`, so I suppose we should make a habit of doing that every so often.

Closes #16 