### PR TITLE
Refactor: Clean up pointer utilities

### DIFF
--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -18,6 +18,11 @@ class EmPtr {
     }
 };
 
+class EmVoidPtr : public EmPtr {
+  public:
+    EmVoidPtr() : EmPtr() {}
+};
+
 bool EmSFileCloseArchive(EmPtr& pMpq) {
   return SFileCloseArchive(pMpq.ptr);
 }
@@ -43,6 +48,9 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
     .constructor()
     .function("getAddr", &EmPtr::getAddr)
     .function("isNull", &EmPtr::isNull);
+
+  class_<EmVoidPtr, base<EmPtr>>("VoidPtr")
+    .constructor();
 
   function("GetLastError", &GetLastError);
 

--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -23,6 +23,18 @@ class EmVoidPtr : public EmPtr {
     EmVoidPtr() : EmPtr() {}
 };
 
+class EmUint32Ptr : public EmPtr {
+  public:
+    EmUint32Ptr() : EmPtr() {
+      uint32_t value = 0;
+      ptr = &value;
+    }
+
+    uint32_t toJS() const {
+      return *(uint32_t*)ptr;
+    }
+};
+
 bool EmSFileCloseArchive(EmPtr& pMpq) {
   return SFileCloseArchive(pMpq.ptr);
 }
@@ -51,6 +63,10 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
 
   class_<EmVoidPtr, base<EmPtr>>("VoidPtr")
     .constructor();
+
+  class_<EmUint32Ptr, base<EmPtr>>("Uint32Ptr")
+    .constructor()
+    .function("toJS", &EmUint32Ptr::toJS);
 
   function("GetLastError", &GetLastError);
 

--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -5,14 +5,16 @@ using namespace emscripten;
 
 class EmPtr {
   public:
-    void* ptr;
+    void* ptr = nullptr;
 
-    uint32_t toUint32() const {
-      return *(uint32_t*)ptr;
+    EmPtr() {}
+
+    size_t getAddr() const {
+      return (size_t)ptr;
     }
 
-    void nullify() {
-      ptr = nullptr;
+    bool isNull() const {
+      return ptr == nullptr;
     }
 };
 
@@ -39,8 +41,8 @@ bool EmSFileOpenFileEx(EmPtr& pMpq, const std::string& sFileName, uint32_t uSear
 EMSCRIPTEN_BINDINGS(EmStormLib) {
   class_<EmPtr>("Ptr")
     .constructor()
-    .function("toUint32", &EmPtr::toUint32)
-    .function("nullify", &EmPtr::nullify);
+    .function("getAddr", &EmPtr::getAddr)
+    .function("isNull", &EmPtr::isNull);
 
   function("GetLastError", &GetLastError);
 

--- a/src/lib/mpq.mjs
+++ b/src/lib/mpq.mjs
@@ -20,7 +20,7 @@ class MPQ {
 
   openFile(fileName) {
     if (this.handle) {
-      const fileHandle = new StormLib.Ptr();
+      const fileHandle = new StormLib.VoidPtr();
 
       if (StormLib.SFileOpenFileEx(this.handle, fileName, 0, fileHandle)) {
         return new File(fileHandle);
@@ -37,7 +37,7 @@ class MPQ {
 MPQ.open = async function (path, flags = 0) {
   await StormLib.ready;
 
-  const handle = new StormLib.Ptr();
+  const handle = new StormLib.VoidPtr();
   const priority = 0;
 
   if (StormLib.SFileOpenArchive(path, priority, flags, handle)) {

--- a/src/lib/stormlib.js
+++ b/src/lib/stormlib.js
@@ -20,6 +20,9 @@ const library = StormLib({
     // Temporary workaround for emscripten pseudo-promise
     delete library.then;
 
+    // Add NULLPTR constant
+    library.NULLPTR = new library.Ptr();
+
     if (process.env.NODE_ENV !== 'production') {
       // eslint-disable-next-line no-console
       console.info('Initialized StormLib in debug mode');

--- a/src/spec/file.spec.js
+++ b/src/spec/file.spec.js
@@ -27,7 +27,7 @@ describe('File', () => {
       const file = mpq.openFile('fixture.txt');
 
       const originalHandle = file.handle;
-      const invalidHandle = new StormLib.Ptr();
+      const invalidHandle = new StormLib.VoidPtr();
 
       try {
         file.handle = invalidHandle;

--- a/src/spec/mpq.spec.js
+++ b/src/spec/mpq.spec.js
@@ -34,7 +34,7 @@ describe('MPQ', () => {
 
       const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
       const originalHandle = mpq.handle;
-      const invalidHandle = new StormLib.Ptr();
+      const invalidHandle = new StormLib.VoidPtr();
 
       try {
         mpq.handle = invalidHandle;


### PR DESCRIPTION
Prep work for implementation of #6. Permits passing in `nullptr` from the JS side when calling bound functions.

`StormLib` has several functions with optional arguments. These arguments can either be, for example, `uint32_t*` or `nullptr`. If you want to get the value placed in an optional argument, you'd pass in a valid pointer. If you don't care, you'd pass in a `nullptr` (and skip a stack allocation).

Embind doesn't really deal with pointers at all, which is why we have the `EmPtr` classes. With this refactor, in the example above, you'd pass in either an instance of `StormLib.Uint32Ptr` or the constant `StormLib.NULLPTR`.

Closes #21 