### PR TITLE
Implement file reading

### DIFF
--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -35,12 +35,39 @@ class EmUint32Ptr : public EmPtr {
     }
 };
 
+class EmBuf {
+  public:
+    uint32_t size;
+    uint8_t* ptr;
+
+    EmBuf(uint32_t s) {
+      size = s;
+      ptr = new uint8_t[s];
+    }
+
+    ~EmBuf() {
+      delete ptr;
+    }
+
+    uint32_t getSize() const {
+      return size;
+    }
+
+    val toJS() {
+      return val(typed_memory_view(size, ptr));
+    }
+};
+
 bool EmSFileCloseArchive(EmPtr& pMpq) {
   return SFileCloseArchive(pMpq.ptr);
 }
 
 bool EmSFileCloseFile(EmPtr& pFile) {
   return SFileCloseFile(pFile.ptr);
+}
+
+uint32_t EmSFileGetFileSize(EmPtr& pFile, EmPtr& pFileSizeHigh) {
+  return SFileGetFileSize(pFile.ptr, static_cast<uint32_t*>(pFileSizeHigh.ptr));
 }
 
 bool EmSFileHasFile(EmPtr& pMpq, const std::string& sFileName) {
@@ -55,7 +82,16 @@ bool EmSFileOpenFileEx(EmPtr& pMpq, const std::string& sFileName, uint32_t uSear
   return SFileOpenFileEx(pMpq.ptr, sFileName.c_str(), uSearchScope, &pFile.ptr);
 }
 
+bool EmSFileReadFile(EmPtr& pFile, EmBuf& bData, uint32_t uToRead, EmPtr& pRead, EmPtr& pOverlapped) {
+  return SFileReadFile(pFile.ptr, bData.ptr, uToRead, static_cast<uint32_t*>(pRead.ptr), static_cast<uint32_t*>(pOverlapped.ptr));
+}
+
 EMSCRIPTEN_BINDINGS(EmStormLib) {
+  class_<EmBuf>("Buf")
+    .constructor<uint32_t>()
+    .function("getSize", &EmBuf::getSize)
+    .function("toJS", &EmBuf::toJS);
+
   class_<EmPtr>("Ptr")
     .constructor()
     .function("getAddr", &EmPtr::getAddr)
@@ -72,7 +108,11 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
 
   function("SFileCloseArchive", &EmSFileCloseArchive);
   function("SFileCloseFile", &EmSFileCloseFile);
+  function("SFileGetFileSize", &EmSFileGetFileSize);
   function("SFileHasFile", &EmSFileHasFile);
   function("SFileOpenArchive", &EmSFileOpenArchive);
   function("SFileOpenFileEx", &EmSFileOpenFileEx);
+  function("SFileReadFile", &EmSFileReadFile);
+
+  constant("SFILE_INVALID_SIZE", SFILE_INVALID_SIZE);
 }

--- a/src/lib/file.mjs
+++ b/src/lib/file.mjs
@@ -1,8 +1,24 @@
 import StormLib from './stormlib';
 
+const PIPE_CHUNK_SIZE = 128 * 1024;
+
 class File {
   constructor(handle) {
     this.handle = handle;
+    this.data = null;
+  }
+
+  get size() {
+    this._ensureHandle();
+
+    const size = StormLib.SFileGetFileSize(this.handle, StormLib.NULLPTR);
+
+    if (size === StormLib.SFILE_INVALID_SIZE) {
+      const errno = StormLib.GetLastError();
+      throw new Error(`File size could not be determined (error ${errno})`);
+    }
+
+    return size;
   }
 
   close() {
@@ -10,10 +26,81 @@ class File {
       if (StormLib.SFileCloseFile(this.handle)) {
         this.handle.delete();
         this.handle = null;
+
+        if (this.data) {
+          this.data.delete();
+          this.data = null;
+        }
       } else {
         const errno = StormLib.GetLastError();
         throw new Error(`Archive could not be closed (error ${errno})`);
       }
+    }
+  }
+
+  pipe(stream) {
+    this._ensureHandle();
+
+    const size = this.size;
+
+    let remainSize = size;
+    let readSize = Math.min(PIPE_CHUNK_SIZE, size);
+
+    const data = new StormLib.Buf(readSize);
+
+    try {
+      while (readSize > 0) {
+        let success = StormLib.SFileReadFile(
+          this.handle, data, readSize, StormLib.NULLPTR, StormLib.NULLPTR
+        );
+
+        if (success) {
+          if (readSize === PIPE_CHUNK_SIZE) {
+            stream.write(data.toJS());
+          } else {
+            stream.write(data.toJS().subarray(0, readSize));
+          }
+
+          remainSize -= readSize;
+          readSize = Math.min(PIPE_CHUNK_SIZE, remainSize);
+        } else {
+          const errno = StormLib.GetLastError();
+          throw new Error(`File could not be piped (error ${errono})`);
+        }
+      }
+    } finally {
+      data.delete();
+      stream.end();
+    }
+  }
+
+  read() {
+    this._ensureHandle();
+
+    const size = this.size;
+
+    if (!this.data) {
+      this.data = new StormLib.Buf(size);
+    }
+
+    const success = StormLib.SFileReadFile(
+      this.handle, this.data, size, StormLib.NULLPTR, StormLib.NULLPTR
+    );
+
+    if (success) {
+      return this.data.toJS();
+    } else {
+      this.data.delete();
+      this.data = null;
+
+      const errno = StormLib.GetLastError();
+      throw new Error(`File could not be read (error ${errno})`);
+    }
+  }
+
+  _ensureHandle() {
+    if (!this.handle) {
+      throw new Error('Invalid handle');
     }
   }
 }

--- a/src/spec/file.spec.js
+++ b/src/spec/file.spec.js
@@ -4,6 +4,22 @@ import StormLib from '../lib/stormlib';
 
 const rootDir = path.resolve(__filename, '../../../');
 
+class MockStream {
+  constructor() {
+    this.data = new Buffer([]);
+  }
+
+  write(data) {
+    this.data = Buffer.concat([this.data, data]);
+  }
+
+  toArray() {
+    return new Uint8Array(this.data);
+  }
+
+  end() {}
+}
+
 describe('File', () => {
   beforeAll(() => {
     FS.mkdir('/fixture');
@@ -51,6 +67,169 @@ describe('File', () => {
       expect(result).toBeUndefined();
 
       mpq.close();
+    });
+  });
+
+  describe('Reading', () => {
+    test('gets size for a valid file', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const result = file.size;
+
+      expect(result).toBe(13);
+
+      file.close();
+      mpq.close();
+    });
+
+    test('throws if getting size for a closed file', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      file.close();
+
+      try {
+        const result = file.size;
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        mpq.close();
+      }
+    });
+
+    test('throws if getting size for a file with an invalid handle', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const originalHandle = file.handle;
+      const invalidHandle = new StormLib.VoidPtr();
+
+      file.handle = invalidHandle;
+
+      try {
+        const size = file.size;
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        file.handle = originalHandle;
+        file.close();
+        mpq.close();
+      }
+    });
+
+    test('pipes valid file into stream', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      const stream = new MockStream();
+
+      file.pipe(stream);
+
+      expect(stream.toArray()).toEqual(new Uint8Array([
+        102, 105, 120, 116, 117, 114, 101, 45, 116, 101, 120, 116, 10
+      ]));
+
+      file.close();
+      mpq.close();
+    });
+
+    test('throws if piping a closed file', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      const stream = new MockStream();
+      file.close();
+
+      try {
+        file.pipe(stream);
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        mpq.close();
+      }
+    });
+
+    test('throws if piping a file with an invalid handle', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      const stream = new MockStream();
+
+      Object.defineProperty(file, 'size', { get: () => 1 });
+
+      const originalHandle = file.handle;
+      const invalidHandle = new StormLib.VoidPtr();
+
+      file.handle = invalidHandle;
+
+      try {
+        file.pipe(stream);
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        file.handle = originalHandle;
+        file.close();
+        mpq.close();
+      }
+    });
+
+    test('reads valid file', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const result = file.read();
+
+      expect(result).toEqual(new Uint8Array([
+        102, 105, 120, 116, 117, 114, 101, 45, 116, 101, 120, 116, 10
+      ]));
+
+      file.close();
+      mpq.close();
+    });
+
+    test('throws if reading a closed file', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      file.close();
+
+      try {
+        const data = file.read();
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        mpq.close();
+      }
+    });
+
+    test('throws if reading a file with an invalid handle', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      Object.defineProperty(file, 'size', { get: () => 1 });
+
+      const originalHandle = file.handle;
+      const invalidHandle = new StormLib.VoidPtr();
+
+      file.handle = invalidHandle;
+
+      try {
+        const data = file.read();
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+      } finally {
+        file.handle = originalHandle;
+        file.close();
+        mpq.close();
+      }
     });
   });
 });


### PR DESCRIPTION
This implements two forms of file reading:

- `pipe()` pipes the file in 128KB chunks into a writable stream; useful to prevent allocating large chunks of memory when reading bigger files

- `read()` returns a `Uint8Array` containing the entire file; use of the array after a file is closed is dangerous

Closes #6 