### PR TITLE
Feature: MPQ patching

### DIFF
--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -116,6 +116,10 @@ bool EmSFileOpenArchive(const std::string& sMpqName, uint32_t uPriority, uint32_
   return SFileOpenArchive(sMpqName.c_str(), uPriority, uFlags, &pMpq.ptr);
 }
 
+bool EmSFileOpenPatchArchive(EmPtr& pMpq, const std::string& sMpqName, const std::string& sPatchPathPrefix, uint32_t uFlags) {
+  return SFileOpenPatchArchive(pMpq.ptr, sMpqName.c_str(), sPatchPathPrefix.c_str(), uFlags);
+}
+
 bool EmSFileOpenFileEx(EmPtr& pMpq, const std::string& sFileName, uint32_t uSearchScope, EmPtr& pFile) {
   return SFileOpenFileEx(pMpq.ptr, sFileName.c_str(), uSearchScope, &pFile.ptr);
 }
@@ -169,6 +173,7 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
   function("SFileGetFileSize", &EmSFileGetFileSize);
   function("SFileHasFile", &EmSFileHasFile);
   function("SFileOpenArchive", &EmSFileOpenArchive);
+  function("SFileOpenPatchArchive", &EmSFileOpenPatchArchive);
   function("SFileOpenFileEx", &EmSFileOpenFileEx);
   function("SFileReadFile", &EmSFileReadFile);
   function("SFileSetFilePointer", &EmSFileSetFilePointer);
@@ -177,4 +182,5 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
   constant("ERROR_NO_MORE_FILES", ERROR_NO_MORE_FILES);
   constant("FILE_BEGIN", FILE_BEGIN);
   constant("SFILE_INVALID_SIZE", SFILE_INVALID_SIZE);
+  constant("STREAM_FLAG_READ_ONLY", STREAM_FLAG_READ_ONLY);
 }

--- a/src/lib/mpq.mjs
+++ b/src/lib/mpq.mjs
@@ -49,6 +49,15 @@ class MPQ {
     }
   }
 
+  patch(path, prefix = '') {
+    this._ensureHandle();
+
+    if (!StormLib.SFileOpenPatchArchive(this.handle, path, prefix, 0)) {
+      const errno = StormLib.GetLastError();
+      throw new Error(`Patch failed (error ${errno})`);
+    }
+  }
+
   search(mask, listfile = '') {
     this._ensureHandle();
 
@@ -91,8 +100,14 @@ class MPQ {
     }
   }
 
-  static async open(path, flags = 0) {
+  static async open(path, mode = '') {
     await StormLib.ready;
+
+    let flags = 0;
+
+    if (mode === 'r') {
+      flags |= StormLib.STREAM_FLAG_READ_ONLY;
+    }
 
     const handle = new StormLib.VoidPtr();
     const priority = 0;

--- a/src/spec/mpq.spec.js
+++ b/src/spec/mpq.spec.js
@@ -19,31 +19,6 @@ describe('MPQ', () => {
       expect(mpq).toBeInstanceOf(MPQ);
     });
 
-    test('patches MPQ', async () => {
-      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
-      mpq.patch('/fixture/size.mpq');
-
-      const result1 = mpq.hasFile('fixture.txt');
-      const result2 = mpq.hasFile('fixture-64kb.txt');
-
-      expect(result1).toBe(true);
-      expect(result2).toBe(true);
-
-      mpq.close();
-    });
-
-    test('throws if patching MPQ with nonexistent MPQ', async () => {
-      expect.assertions(1);
-
-      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
-
-      try {
-        mpq.patch('/fixture/nonexistent.mpq');
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-      }
-    });
-
     test('throws if opening nonexistent MPQ', async () => {
       expect.assertions(1);
 
@@ -79,6 +54,29 @@ describe('MPQ', () => {
       const result = mpq.close();
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('Patching', () => {
+    test('patches MPQ', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
+      mpq.patch('/fixture/size.mpq');
+
+      const result1 = mpq.hasFile('fixture.txt');
+      const result2 = mpq.hasFile('fixture-64kb.txt');
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+
+      mpq.close();
+    });
+
+    test('throws if patching MPQ with nonexistent MPQ', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
+
+      expect(() => mpq.patch('/fixture/nonexistent.mpq')).toThrow(Error);
+
+      mpq.close();
     });
   });
 

--- a/src/spec/mpq.spec.js
+++ b/src/spec/mpq.spec.js
@@ -19,6 +19,31 @@ describe('MPQ', () => {
       expect(mpq).toBeInstanceOf(MPQ);
     });
 
+    test('patches MPQ', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
+      mpq.patch('/fixture/size.mpq');
+
+      const result1 = mpq.hasFile('fixture.txt');
+      const result2 = mpq.hasFile('fixture-64kb.txt');
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+
+      mpq.close();
+    });
+
+    test('throws if patching MPQ with nonexistent MPQ', async () => {
+      expect.assertions(1);
+
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq', 'r');
+
+      try {
+        mpq.patch('/fixture/nonexistent.mpq');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+
     test('throws if opening nonexistent MPQ', async () => {
       expect.assertions(1);
 


### PR DESCRIPTION
MPQ patching requires the initial MPQ be opened as read-only, so the signature of MPQ.open has been adjusted to make specifying access modes straightforward.

Closes #18 