### PR TITLE
Fix: MPQs > 2GB fail to load

### DIFF
--- a/scripts/build-stormlib.js
+++ b/scripts/build-stormlib.js
@@ -137,6 +137,7 @@ async function buildDebug(buildRoot, distDir) {
     '-s ALLOW_MEMORY_GROWTH=1',
     '-s SINGLE_FILE=1',
     '-s MODULARIZE=1',
+    '-s DEMANGLE_SUPPORT=1',
     '-s EXPORT_NAME="\'StormLib\'"',
     '-s EXTRA_EXPORTED_RUNTIME_METHODS="[\'FS\']"',
     '-o stormlib.debug.js'

--- a/scripts/build-stormlib.js
+++ b/scripts/build-stormlib.js
@@ -98,7 +98,7 @@ async function buildDebug(buildRoot, distDir) {
 
   const cmakeFlags = [
     '-DBUILD_SHARED_LIBS=1',
-    '-DCMAKE_BUILD_TYPE=Debug'
+    '-DCMAKE_BUILD_TYPE=Release'
   ];
 
   const { cmakeOut, cmakeErr } = await emcmake(cmakeFlags, './StormLib');

--- a/scripts/build-stormlib.js
+++ b/scripts/build-stormlib.js
@@ -133,6 +133,7 @@ async function buildDebug(buildRoot, distDir) {
 
   const wasmCompileFlags = sharedCompileFlags.concat([
     '--bind',
+    '--post-js ../../src/binding/post.js',
     '-s WASM=1',
     '-s ALLOW_MEMORY_GROWTH=1',
     '-s SINGLE_FILE=1',
@@ -202,6 +203,7 @@ async function buildRelease(buildRoot, distDir) {
 
   const wasmCompileFlags = sharedCompileFlags.concat([
     '--bind',
+    '--post-js ../../src/binding/post.js',
     '-s WASM=1',
     '-s ALLOW_MEMORY_GROWTH=1',
     '-s SINGLE_FILE=1',

--- a/src/binding/post.js
+++ b/src/binding/post.js
@@ -1,0 +1,26 @@
+function ___syscall140(which, varargs) {
+  SYSCALLS.varargs = varargs;
+  try {
+    // llseek
+    var stream = SYSCALLS.getStreamFromFD(), offset_high = SYSCALLS.get(), offset_low = SYSCALLS.get(), result = SYSCALLS.get(), whence = SYSCALLS.get();
+    // NOTE: offset_high is unused - Emscripten's off_t is 32-bit
+
+    // Ugly workaround for seeking >= 2 ** 31 bytes
+    //
+    // If whence is SEEK_SET, assume the value cannot be negative. This permits
+    // SEEK_SET to seek to offsets >= 2 ** 31 and <= 2 ** 32.
+    //
+    // This workaround does *not* account for cases where offsets used with
+    // SEEK_CUR or SEEK_END are >= 2 ** 31. Such cases will produce unexpected
+    // behavior.
+    var offset = whence === 0 ? offset_low >>> 0 : offset_low;
+
+    FS.llseek(stream, offset, whence);
+    HEAP32[((result)>>2)]=stream.position;
+    if (stream.getdents && offset === 0 && whence === 0) stream.getdents = null; // reset readdir state
+    return 0;
+  } catch (e) {
+    if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);
+    return -e.errno;
+  }
+}


### PR DESCRIPTION
This fixes two issues with MPQs `>= 2 ** 31` bytes:

- The debug version of StormLib is compiled using CMake's release build type. This prevents some runtime asserts from misbehaving.

- The `llseek` syscall (`___syscall140`) is replaced by a version that works around seeking to offsets `>= 2 ** 31` bytes. This workaround will remain necessary until emscripten starts to use 64-bit integers for seeking offsets.

Closes #28 