### PR TITLE
Feature: get file name from open file

### DIFF
--- a/src/binding/EmStormLib.cpp
+++ b/src/binding/EmStormLib.cpp
@@ -58,6 +58,29 @@ class EmBuf {
     }
 };
 
+class EmStr {
+  public:
+    uint32_t size;
+    char* ptr;
+
+    EmStr(uint32_t s) {
+      size = s;
+      ptr = new char[s];
+    }
+
+    ~EmStr() {
+      delete ptr;
+    }
+
+    uint32_t getSize() const {
+      return size;
+    }
+
+    val toJS() {
+      return val(std::string(ptr));
+    }
+};
+
 bool EmSFileCloseArchive(EmPtr& pMpq) {
   return SFileCloseArchive(pMpq.ptr);
 }
@@ -104,6 +127,10 @@ bool EmSFileFindNextFile(EmPtr& pFind, SFILE_FIND_DATA& pFindFileData) {
   return SFileFindNextFile(pFind.ptr, &pFindFileData);
 }
 
+bool EmSFileGetFileName(EmPtr& pFile, EmStr& sName) {
+  return SFileGetFileName(pFile.ptr, sName.ptr);
+}
+
 uint32_t EmSFileGetFileSize(EmPtr& pFile, EmPtr& pFileSizeHigh) {
   return SFileGetFileSize(pFile.ptr, static_cast<uint32_t*>(pFileSizeHigh.ptr));
 }
@@ -143,6 +170,11 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
     .function("getAddr", &EmPtr::getAddr)
     .function("isNull", &EmPtr::isNull);
 
+  class_<EmStr>("Str")
+    .constructor<uint32_t>()
+    .function("getSize", &EmStr::getSize)
+    .function("toJS", &EmStr::toJS);
+
   class_<EmVoidPtr, base<EmPtr>>("VoidPtr")
     .constructor();
 
@@ -170,6 +202,7 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
   function("SFileFindClose", &EmSFileFindClose);
   function("SFileFindFirstFile", &EmSFileFindFirstFile);
   function("SFileFindNextFile", &EmSFileFindNextFile);
+  function("SFileGetFileName", &EmSFileGetFileName);
   function("SFileGetFileSize", &EmSFileGetFileSize);
   function("SFileHasFile", &EmSFileHasFile);
   function("SFileOpenArchive", &EmSFileOpenArchive);
@@ -181,6 +214,7 @@ EMSCRIPTEN_BINDINGS(EmStormLib) {
   constant("ERROR_FILE_NOT_FOUND", ERROR_FILE_NOT_FOUND);
   constant("ERROR_NO_MORE_FILES", ERROR_NO_MORE_FILES);
   constant("FILE_BEGIN", FILE_BEGIN);
+  constant("MAX_PATH", MAX_PATH);
   constant("SFILE_INVALID_SIZE", SFILE_INVALID_SIZE);
   constant("STREAM_FLAG_READ_ONLY", STREAM_FLAG_READ_ONLY);
 }

--- a/src/lib/file/index.mjs
+++ b/src/lib/file/index.mjs
@@ -6,7 +6,23 @@ class File {
     this.handle = handle;
     this.data = null;
 
+    this._name = null;
     this._pos = 0;
+  }
+
+  get name() {
+    this._ensureHandle();
+
+    if (!this._name) {
+      this._name = new StormLib.Str(StormLib.MAX_PATH);
+    }
+
+    if (StormLib.SFileGetFileName(this.handle, this._name)) {
+      return this._name.toJS();
+    } else {
+      const errno = StormLib.GetLastError();
+      throw new Error(`File name could not be read (error ${errno})`);
+    }
   }
 
   get pos() {
@@ -50,6 +66,11 @@ class File {
         if (this.data) {
           this.data.delete();
           this.data = null;
+        }
+
+        if (this._name) {
+          this._name.delete();
+          this._name = null;
         }
       } else {
         const errno = StormLib.GetLastError();

--- a/src/spec/file.spec.js
+++ b/src/spec/file.spec.js
@@ -388,5 +388,57 @@ describe('File', () => {
       file.close();
       mpq.close();
     });
+
+    test('gets name for valid file', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const name = file.name;
+
+      expect(name).toBe('fixture.txt');
+
+      file.close();
+      mpq.close();
+    });
+
+    test('gets name for valid file with repeated calls', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const name1 = file.name;
+      const name2 = file.name;
+
+      expect(name1).toBe(name2);
+
+      file.close();
+      mpq.close();
+    });
+
+    test('throws if getting name for closed file', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+      file.close();
+
+      expect(() => { const name = file.name; }).toThrow(Error);
+
+      mpq.close();
+    });
+
+    test('throws if getting name for file with invalid handle', async () => {
+      const mpq = await MPQ.open('/fixture/vanilla-standard.mpq');
+      const file = mpq.openFile('fixture.txt');
+
+      const originalHandle = file.handle;
+      const invalidHandle = new StormLib.VoidPtr();
+
+      file.handle = invalidHandle;
+
+      expect(() => { const name = file.name; }).toThrow(Error);
+
+      invalidHandle.delete();
+      file.handle = originalHandle;
+      file.close();
+      mpq.close();
+    });
   });
 });


### PR DESCRIPTION
It's now possible to call `.name` to get the file name for a file opened using `MPQ.prototype.openFile`.

Closes #31 