### PR TITLE
chore: update emscripten

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Development of StormJS requires git, CMake, and an Emscripten environment.
 
 [emsdk](https://github.com/juj/emsdk) is the simplest way to get an Emscripten environment up and running.
 
-StormJS is currently built using Emscripten 1.38.11.
+StormJS is currently built using Emscripten 1.39.15.
 
 After cloning the StormJS repo, ensure all submodules are also pulled down from remote by running:
 

--- a/scripts/build-stormlib.js
+++ b/scripts/build-stormlib.js
@@ -211,6 +211,7 @@ async function buildRelease(buildRoot, distDir) {
     '-s MODULARIZE=1',
     '-s EXPORT_NAME="\'StormLib\'"',
     '-s EXTRA_EXPORTED_RUNTIME_METHODS="[\'FS\']"',
+    '-l nodefs.js',
     '-o stormlib.release.js'
   ]);
 

--- a/scripts/build-stormlib.js
+++ b/scripts/build-stormlib.js
@@ -141,11 +141,12 @@ async function buildDebug(buildRoot, distDir) {
     '-s DEMANGLE_SUPPORT=1',
     '-s EXPORT_NAME="\'StormLib\'"',
     '-s EXTRA_EXPORTED_RUNTIME_METHODS="[\'FS\']"',
+    '-l nodefs.js',
     '-o stormlib.debug.js'
   ]);
 
   const wasmFiles = [
-    'libstorm.so',
+    'libstorm.a',
     'EmStormLib.bc'
   ];
 
@@ -214,7 +215,7 @@ async function buildRelease(buildRoot, distDir) {
   ]);
 
   const wasmFiles = [
-    'libstorm.so',
+    'libstorm.a',
     'EmStormLib.bc'
   ];
 


### PR DESCRIPTION
This brings support for emscripten 1.39.15.

Moving to 1.39.16 and beyond will need to wait until top-level await is supported in Node and browsers.