### PR TITLE
chore!: update node support to require node 10 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note that StormJS loads in production mode if `NODE_ENV` is set to `production`.
 
 ## Compatibility
 
-StormJS is tested against Node 8 and Node 10.
+StormJS is tested against Node 10, 12, and 14.
 
 Additionally, StormJS should work well in browsers with support for WASM. Note that use in browsers will require configuring an Emscripten filesystem type appropriate for the browser.
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,7 @@ module.exports = {
           '@babel/preset-env',
           {
             targets: {
-              node: '8.11',
+              node: '10',
             },
           },
         ],
@@ -19,7 +19,7 @@ module.exports = {
           '@babel/preset-env',
           {
             targets: {
-              node: '8.11',
+              node: '10',
               browsers: ['last 2 versions', 'not ie 1-11', 'not android > 0'],
             },
             modules: false,
@@ -34,7 +34,7 @@ module.exports = {
           '@babel/preset-env',
           {
             targets: {
-              node: '8.11',
+              node: '10',
             },
           },
         ],


### PR DESCRIPTION
BREAKING CHANGE: We no longer support Node 8 or earlier. Node 10 is the oldest version actively maintained.