### PR TITLE
fix: use module field as esm hint for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "StormLib for Javascript, powered by Emscripten",
   "main": "dist/index",
+  "module": "dist/index.mjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This makes it possible for some bundlers to prefer the ES module version of the library without having to prioritize `.mjs` ahead of `.js` for file resolution.